### PR TITLE
adds intial "Beast of Burden (Keyboard Percussion)" post

### DIFF
--- a/index.md
+++ b/index.md
@@ -53,6 +53,21 @@ See a demo here: <a href="http://carraway.me/toyota">http://carraway.me/toyota</
      alt="Toyota Multi-Point Inspection 1">
 
 <hr>
+
+## Beast of Burden (Keyboard Percussion)
+_September 22, 2011_
+
+"Beast of Burden" by the Rolling Stones arranged for marimba, vibraphone, bells, and percussion.
+Arranged and performed by Eric Carraway.
+
+<iframe width="100%" height="450" scrolling="no" frameborder="no"
+src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/23887807&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;visual=true">
+</iframe>
+<!-- #TODO: update this dynamically via the SoundCloud API -->
+_695 plays since Sep 22, 2011_
+
+<hr>
+
 {% if site.data.environment.is_local %}
 <span style="color: red;">
       site.data.environment.is_local


### PR DESCRIPTION
Beast of Burden (Keyboard Percussion)
September 22, 2011

“Beast of Burden” by the Rolling Stones arranged for marimba, vibraphone, bells, and percussion. Arranged and performed by Eric Carraway.
https://soundcloud.com/eric-carraway/beast-of-burden-percussion
